### PR TITLE
fix: Refresh

### DIFF
--- a/src/components/Refresh.js
+++ b/src/components/Refresh.js
@@ -18,7 +18,7 @@ const Refresh = () => {
     <>
       <button onClick={() => navigate(-1)}>go back</button>
       <Routes>
-        <Route exact path="/" element={<Persons/>}/>
+        <Route exact path="/" element={<Persons persons={[]} />}/>
       </Routes>
     </>
   )


### PR DESCRIPTION
Fix `persons` props in `<Refresh />` component to be an array.
In the `Persons` component, you expect `props.persons` to be an array in order to `map` over it.
In your `Refresh` component, you did not pass any props at all. Therefore `persons` will be `undefined` and you can not call `.map()` on `undefined`.

I'm not entirely sure how you are planning to use the `Refresh` component but currently, this results in an infinite loop of refreshing the page. 